### PR TITLE
Use connection args when using mysql_database.present / mysql_user.present / mysql_grants.present

### DIFF
--- a/mysql/map.jinja
+++ b/mysql/map.jinja
@@ -26,3 +26,13 @@
         }
     },
 }, merge=salt['pillar.get']('mysql:server')) %}
+
+{%- if server.admin is defined %}
+{%- set mysql_connection_args = {'user': server.admin.user,
+                                 'password': server.admin.password,
+                                 'charset': 'utf8'} %}
+{%- else %}
+{%- set mysql_connection_args = {'user': 'root',
+                                 'password': '',
+                                 'charset': 'utf8'} %}
+{%- endif %}

--- a/mysql/server/database.sls
+++ b/mysql/server/database.sls
@@ -1,4 +1,4 @@
-{%- from "mysql/map.jinja" import server with context %}
+{%- from "mysql/map.jinja" import server, mysql_connection_args with context %}
 
 {%- if not grains.get('noservices', False) %}
 {%- for database_name, database in server.get('database', {}).iteritems() %}
@@ -6,6 +6,9 @@
 mysql_database_{{ database_name }}:
   mysql_database.present:
   - name: {{ database_name }}
+  - connection_user: {{ mysql_connection_args.user }}
+  - connection_pass: {{ mysql_connection_args.password }}
+  - connection_charset: {{ mysql_connection_args.charset }}
 
 {%- for user in database.users %}
 
@@ -18,6 +21,9 @@ mysql_user_{{ user.name }}_{{ database_name }}_{{ user.host }}:
   {%- else %}
   - allow_passwordless: true
   {%- endif %}
+  - connection_user: {{ mysql_connection_args.user }}
+  - connection_pass: {{ mysql_connection_args.password }}
+  - connection_charset: {{ mysql_connection_args.charset }}
 
 mysql_grants_{{ user.name }}_{{ database_name }}_{{ user.host }}:
   mysql_grants.present:
@@ -25,6 +31,9 @@ mysql_grants_{{ user.name }}_{{ database_name }}_{{ user.host }}:
   - database: '{{ database_name }}.*'
   - user: '{{ user.name }}'
   - host: '{{ user.host }}'
+  - connection_user: {{ mysql_connection_args.user }}
+  - connection_pass: {{ mysql_connection_args.password }}
+  - connection_charset: {{ mysql_connection_args.charset }}
   - require:
     - mysql_user: mysql_user_{{ user.name }}_{{ database_name }}_{{ user.host }}
     - mysql_database: mysql_database_{{ database_name }}

--- a/mysql/server/service.sls
+++ b/mysql/server/service.sls
@@ -1,4 +1,4 @@
-{%- from "mysql/map.jinja" import server with context %}
+{%- from "mysql/map.jinja" import server, mysql_connection_args with context %}
 
 mysql_salt_config:
   file.managed:
@@ -87,6 +87,9 @@ include:
   mysql_user.present:
   - host: '%'
   - password: {{ server.replication.password }}
+  - connection_user: {{ mysql_connection_args.user }}
+  - connection_pass: {{ mysql_connection_args.password }}
+  - connection_charset: {{ mysql_connection_args.charset }}
   - watch_in:
     - service: mysql_service
 
@@ -96,6 +99,9 @@ include:
   - database: '*.*'
   - user: {{ server.replication.user }}
   - host: '%'
+  - connection_user: {{ mysql_connection_args.user }}
+  - connection_pass: {{ mysql_connection_args.password }}
+  - connection_charset: {{ mysql_connection_args.charset }}
   - watch_in:
     - service: mysql_service
 


### PR DESCRIPTION
This commit fixes the mysql states that needs to connect to MySQL server (mysql_database.present / mysql_user.present / mysql_grants.present).

The file `mysql/server/service.sls` have a state to manage the `/etc/salt/minion.d/mysql.conf` that holds the MySQL configuration for SaltStack minion:

``` sls
mysql_salt_config:
  file.managed:
    - name: /etc/salt/minion.d/mysql.conf
    - template: jinja
    - source: salt://mysql/files/salt-minion.conf
    - mode: 600
```

However this does not work unless you reload/restart minion, so this PR allows running the formula without having to reload/restart minion.
